### PR TITLE
[Feature #137598991] Add exercise details endpoint

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -71,3 +71,12 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Muscle
+
+
+class ExercisesInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise info serializer
+    '''
+    class Meta:
+        model = Exercise
+        depth = 1

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -30,6 +30,7 @@ from wger.exercises.api.serializers import (
     MuscleSerializer,
     ExerciseSerializer,
     ExerciseImageSerializer,
+    ExercisesInfoSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
     ExerciseCommentSerializer
@@ -207,3 +208,23 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')
+
+
+class ExerciseInfoSet(viewsets.ReadOnlyModelViewSet):
+    '''
+    API endpoint for exercise info
+    '''
+    queryset = Exercise.objects.all()
+    serializer_class = ExercisesInfoSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
+    ordering_fields = '__all__'
+    filter_fields = ('category',
+                     'creation_date',
+                     'description',
+                     'language',
+                     'muscles',
+                     'muscles_secondary',
+                     'name',
+                     'equipment',
+                     'license',
+                     'license_author')

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -108,6 +108,7 @@ router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet
 router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')
 router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet, base_name='exercisecomment')
 router.register(r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')
+router.register(r'exercise-details', exercises_api_views.ExerciseInfoSet, base_name='exercise-details')
 
 # Nutrition app
 router.register(r'ingredient', nutrition_api_views.IngredientViewSet, base_name='api-ingredient')


### PR DESCRIPTION
#### What does this PR do?
1. Adds serializer to wger/exercises/api/serializers.py
2. Adds endpoint in wger/exercises/qpi/views.py
3. Registers resource in wger/urls.py
#### Description of Task to be completed?
A new read-only endpoint that collects all the information of an exercise such as muscles, category, images, etc. This makes it easier for clients to get all the infos since only a single request is needed
#### How should this be manually tested?
 1. Clone the repo 
2. Run `python manage.py runserver`
3. Use postman and run a get request to `http://127.0.0.1:8000/api/v2/exercise-details`

![Imgur](http://i.imgur.com/nhGVEJH.png)
![Imgur](http://i.imgur.com/s84p4Eg.png)
